### PR TITLE
Bypass Unknown IR type error by using a Dummy Shading instead

### DIFF
--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -278,7 +278,7 @@ ShadingIRs.Dummy = {
     return {
       type: 'Pattern',
       getPattern: function Dummy_fromIR_getPattern() {
-        return 'hotpink';
+        return 'WhiteSmoke';
       },
     };
   },
@@ -287,7 +287,7 @@ ShadingIRs.Dummy = {
 function getShadingPatternFromIR(raw) {
   var shadingIR = ShadingIRs[raw[0]];
   if (!shadingIR) {
-    throw new Error(`Unknown IR type: ${raw[0]}`);
+    shadingIR = ShadingIRs.Dummy;
   }
   return shadingIR.fromIR(raw);
 }


### PR DESCRIPTION
![pull_request_problem](https://user-images.githubusercontent.com/30271943/33936019-1ed37b16-dfe5-11e7-8f5c-e98ac3937868.PNG)
The related pdf's structure contained a pattern object, which could not be rendered, due its invalid reference. After throwing the `Unknown IR type` error, the page stuck with an loading icon. This modification bypass this error, by returning a 'Dummy' Shading, causing the page to be loaded, by replacing the invalid pattern with an WhiteSmoke (css gray color) canvas.
![pull_request_solution](https://user-images.githubusercontent.com/30271943/33936026-23b5dcdc-dfe5-11e7-8ee7-5f5299e675d6.PNG)

